### PR TITLE
fix: default checkbox state

### DIFF
--- a/src/app/components/checkbox/checkbox.test.tsx
+++ b/src/app/components/checkbox/checkbox.test.tsx
@@ -2,7 +2,14 @@ import React from "react";
 import { Checkbox } from "./checkbox";
 import { render, screen, fireEvent } from "@testing-library/react";
 
-    describe("Checkbox component", () => {
+  describe("Checkbox component", () => {
+      test("defaults to unchecked when no checked prop is provided", () => {
+        render(<Checkbox onChange={() => {}} />);
+        const checkbox = screen.getByRole("checkbox");
+        expect(checkbox).not.toBeChecked();
+        expect(screen.getByText("Inactive")).toBeInTheDocument();
+      });
+
       test("renders with initial state unchecked", () => {
         render(<Checkbox checked={false} onChange={() => {}} />);
         const checkbox = screen.getByRole("checkbox");

--- a/src/app/components/checkbox/checkbox.tsx
+++ b/src/app/components/checkbox/checkbox.tsx
@@ -15,10 +15,7 @@ const Checkbox: React.FC<ToggleSwitchProps> = ({
   checked,
   onChange,
 }) => {
-  const [isChecked, setIsChecked] = React.useState(checked);
-  if (checked === undefined) {
-    checked = false; // Default to false if checked is not provided
-  }
+  const [isChecked, setIsChecked] = React.useState(checked ?? false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const newChecked = e.target.checked;
@@ -27,7 +24,7 @@ const Checkbox: React.FC<ToggleSwitchProps> = ({
   };
 
   React.useEffect(() => {
-    setIsChecked(checked);
+    setIsChecked(checked ?? false);
   }, [checked]);
 
   return (


### PR DESCRIPTION
## Summary
- default Checkbox component to `false` when no checked prop is provided
- test unchecked default state

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6895bb389a44832c854218dfe65faafa