### PR TITLE
feat: add fastapi backend service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,3 +43,5 @@ next-env.d.ts
 
 # experemental 
 /experements
+# python
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-This is the My pet project for learning purposes. I would like to write simple wbsite which allow user to make thier own surveys. 
+This is the My pet project for learning purposes. I would like to write simple wbsite which allow user to make thier own surveys
+.
 
 # Pre-install
 * [node v22.8.0](https://nodejs.org/en/download) or higher
@@ -9,7 +10,29 @@ To install all dependencies for the project
 ```bash
 npm ci
 ```
-To run project 
+To run project
 ```bash
 npm start
+```
+
+## Backend
+
+The backend is built with FastAPI.
+
+### Environment variables
+- `MONGODB_URI`: MongoDB connection string.
+- `MONGODB_DB`: Name of the database.
+
+### Run locally
+Install Python dependencies and start the development server:
+```bash
+pip install -r backend/requirements.txt
+uvicorn backend.main:app --reload
+```
+
+### Docker
+Build and run the backend in Docker:
+```bash
+docker build -t survey-backend -f backend/Dockerfile .
+docker run -p 8000:8000 --env MONGODB_URI=<your-uri> --env MONGODB_DB=<db-name> survey-backend
 ```

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,11 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY backend/requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY backend /app/backend
+
+EXPOSE 8000
+CMD ["uvicorn", "backend.main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/backend/main.py
+++ b/backend/main.py
@@ -1,0 +1,48 @@
+import os
+from typing import List, Optional
+
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+import motor.motor_asyncio
+from bson import ObjectId
+
+
+class QuestionItem(BaseModel):
+    id: str
+    questionText: str
+    component: str
+    option: Optional[List[str]] = None
+    layout: Optional[str] = None
+
+
+class Survey(BaseModel):
+    id: Optional[str] = None
+    title: Optional[str] = None
+    questions: List[QuestionItem]
+
+
+app = FastAPI()
+
+MONGODB_URI = os.getenv("MONGODB_URI", "mongodb://localhost:27017")
+MONGODB_DB = os.getenv("MONGODB_DB", "survey")
+
+client = motor.motor_asyncio.AsyncIOMotorClient(MONGODB_URI)
+db = client[MONGODB_DB]
+surveys_collection = db["surveys"]
+
+
+@app.post("/surveys")
+async def create_survey(survey: Survey):
+    survey_dict = survey.model_dump(exclude_none=True)
+    result = await surveys_collection.insert_one(survey_dict)
+    return {"id": str(result.inserted_id)}
+
+
+@app.get("/surveys/{id}", response_model=Survey)
+async def get_survey(id: str):
+    survey = await surveys_collection.find_one({"_id": ObjectId(id)})
+    if not survey:
+        raise HTTPException(status_code=404, detail="Survey not found")
+    survey["id"] = str(survey["_id"])
+    survey.pop("_id", None)
+    return Survey(**survey)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,0 +1,3 @@
+fastapi
+uvicorn
+motor


### PR DESCRIPTION
## Summary
- add FastAPI backend with MongoDB integration
- document backend setup and environment variables
- ignore Python bytecode

## Testing
- `python -m py_compile backend/main.py`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68ac9bd9dfbc832c80fb90d3c4e50104