### PR TITLE
feat: add survey api utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,11 @@ npm start
 
 If a `dev` script is not present you can use `npm start` as the project was previously using that command.
 
+Environment variables (frontend):
+
+- `NEXT_PUBLIC_API_URL` — Base URL of the backend API (e.g. `http://localhost:8000`).
+  The frontend uses this to issue `fetch` requests to the `/surveys` endpoints.
+
 ## Backend (FastAPI)
 
 The backend lives in `backend/` and uses FastAPI. It expects a MongoDB database to store survey data.

--- a/frontend/src/app/app-modules/sidebar/sidebar.tsx
+++ b/frontend/src/app/app-modules/sidebar/sidebar.tsx
@@ -17,6 +17,7 @@ const Sidebar: React.FC<SidebarProps> = ({ buttons }) => {
               onClick={button.onClick}
               className={button.className}
               test_id={button.test_id || undefined}
+              disabled={button.disabled}
             />
           </li>
         ))}

--- a/frontend/src/app/components/button/button.test.tsx
+++ b/frontend/src/app/components/button/button.test.tsx
@@ -31,6 +31,12 @@ describe('Button component', () => {
         expect(buttonElement).toBeInTheDocument()
     })
 
+    test('respects disabled prop', () => {
+        render(<Button label="Click me" disabled />)
+        const buttonElement = screen.getByText(/Click me/i)
+        expect(buttonElement).toBeDisabled()
+    })
+
     test('calls onClick prop when clicked', () => {
         const handleClick = vi.fn()
         render(<Button label="Click me" onClick={handleClick} />)

--- a/frontend/src/app/components/button/button.tsx
+++ b/frontend/src/app/components/button/button.tsx
@@ -7,11 +7,14 @@ export interface ButtonProps {
     onClick?: () => void;
     className?: string;
     test_id?: string;
+    disabled?: boolean;
 }
 
-const Button: React.FC<ButtonProps> = ({ label, className='button-base', test_id, onClick }) => {
+const Button: React.FC<ButtonProps> = ({ label, className = 'button-base', test_id, onClick, disabled }) => {
     return (
-        <button className={className} data-testid={test_id} onClick={onClick}>{label}</button>
+        <button className={className} data-testid={test_id} onClick={onClick} disabled={disabled}>
+            {label}
+        </button>
     );
 };
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -12,6 +12,8 @@ import { getPopupComponentsAndOptions } from './app-modules/pop-up/pop-up-questi
 import { createNewQuestion } from './app-modules/questions/questions-factory'
 import { DeleteDropzone } from './components/deleteDropzone/deleteDropzone'
 import './styles.css'
+import { saveSurvey, fetchSurvey } from './services/surveys'
+import type { Layouts } from 'react-grid-layout'
 
 export default function Home() {
     const [isPopUpOpen, setIsPopUpOpen] = useState(false)
@@ -20,6 +22,8 @@ export default function Home() {
 
     const [isDragging, setIsDragging] = useState(false)
     const [isOverTrash, setIsOverTrash] = useState(false)
+    const [saving, setSaving] = useState(false)
+    const [loadingSurvey, setLoadingSurvey] = useState(false)
 
     const layoutsApi = useLayouts()
     const builder = useQuestionBuilder()
@@ -40,6 +44,43 @@ export default function Home() {
     const handleClose = () => {
         setIsPopUpOpen(false)
         builder.reset()
+    }
+
+    const handleSaveSurvey = async () => {
+        setSaving(true)
+        try {
+            const { id } = await saveSurvey({ questions })
+            alert(`Survey saved with id: ${id}`)
+        } catch (e) {
+            console.error(e)
+            alert('Failed to save survey')
+        } finally {
+            setSaving(false)
+        }
+    }
+
+    const handleLoadSurvey = async () => {
+        const id = prompt('Enter survey id')
+        if (!id) return
+        setLoadingSurvey(true)
+        try {
+            const survey = await fetchSurvey(id)
+            setQuestions(survey.questions)
+            const layouts: Layouts = {
+                lg: survey.questions.map(q => q.layout),
+                md: survey.questions.map(q => q.layout),
+                sm: survey.questions.map(q => q.layout),
+                xs: survey.questions.map(q => q.layout),
+                xxs: survey.questions.map(q => q.layout),
+            }
+            layoutsApi.setLayouts(layouts)
+            alert('Survey loaded')
+        } catch (e) {
+            console.error(e)
+            alert('Failed to load survey')
+        } finally {
+            setLoadingSurvey(false)
+        }
     }
 
     const popup = getPopupComponentsAndOptions({
@@ -123,6 +164,20 @@ export default function Home() {
                             },
                             className: 'button-base',
                             test_id: 'button-2',
+                        },
+                        {
+                            label: saving ? 'Saving...' : 'Save Survey',
+                            onClick: handleSaveSurvey,
+                            className: 'button-base',
+                            test_id: 'button-save',
+                            disabled: saving,
+                        },
+                        {
+                            label: loadingSurvey ? 'Loading...' : 'Load Survey',
+                            onClick: handleLoadSurvey,
+                            className: 'button-base',
+                            test_id: 'button-load',
+                            disabled: loadingSurvey,
                         },
                     ]}
                 />

--- a/frontend/src/app/services/surveys.ts
+++ b/frontend/src/app/services/surveys.ts
@@ -1,0 +1,32 @@
+import { QuestionItem } from '@/app/app-modules/questions/question-types'
+
+const API_URL = process.env.NEXT_PUBLIC_API_URL || ''
+
+export interface SurveyPayload {
+  title?: string
+  questions: QuestionItem[]
+}
+
+export interface SurveyResponse extends SurveyPayload {
+  id: string
+}
+
+export async function saveSurvey(payload: SurveyPayload): Promise<{ id: string }> {
+  const res = await fetch(`${API_URL}/surveys`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to save survey')
+  }
+  return res.json()
+}
+
+export async function fetchSurvey(id: string): Promise<SurveyResponse> {
+  const res = await fetch(`${API_URL}/surveys/${id}`)
+  if (!res.ok) {
+    throw new Error('Failed to load survey')
+  }
+  return res.json()
+}


### PR DESCRIPTION
## Summary
- add fetch-based `/surveys` service helpers
- connect save/load buttons to backend calls with async UI feedback
- document `NEXT_PUBLIC_API_URL` for configuring backend URL

## Testing
- `npm test -- --run`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68ae0635f3d0832c8817ece57a4490c3