### PR TITLE
feat: add auth page with login and registration

### DIFF
--- a/frontend/src/app/auth/page.tsx
+++ b/frontend/src/app/auth/page.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useState } from 'react'
+import { login, register } from '../services/auth'
+
+export default function AuthPage() {
+  const [mode, setMode] = useState<'login' | 'register'>('login')
+  const [email, setEmail] = useState('')
+  const [password, setPassword] = useState('')
+  const [repeat, setRepeat] = useState('')
+  const [error, setError] = useState<string | null>(null)
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError(null)
+    try {
+      if (mode === 'register') {
+        if (password !== repeat) {
+          setError('Passwords do not match')
+          return
+        }
+        await register({ email, password })
+      } else {
+        await login({ email, password })
+      }
+      alert('Success')
+    } catch {
+      setError('Authentication failed')
+    }
+  }
+
+  return (
+    <div className="max-w-md mx-auto p-4">
+      <h1 className="text-2xl mb-4">{mode === 'login' ? 'Login' : 'Register'}</h1>
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          placeholder="Email"
+          className="border p-2"
+          required
+        />
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          placeholder="Password"
+          className="border p-2"
+          required
+        />
+        {mode === 'register' && (
+          <input
+            type="password"
+            value={repeat}
+            onChange={(e) => setRepeat(e.target.value)}
+            placeholder="Repeat password"
+            className="border p-2"
+            required
+          />
+        )}
+        {error && <p className="text-red-500">{error}</p>}
+        <button type="submit" className="bg-blue-500 text-white p-2">
+          {mode === 'login' ? 'Login' : 'Register'}
+        </button>
+      </form>
+      <button
+        onClick={() => setMode(mode === 'login' ? 'register' : 'login')}
+        className="mt-4 text-sm text-blue-500 underline"
+      >
+        {mode === 'login'
+          ? 'Need an account? Register'
+          : 'Already have an account? Login'}
+      </button>
+    </div>
+  )
+}
+

--- a/frontend/src/app/services/auth.ts
+++ b/frontend/src/app/services/auth.ts
@@ -1,0 +1,31 @@
+const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://127.0.0.1:8000'
+
+export interface AuthPayload {
+  email: string
+  password: string
+}
+
+export async function login(payload: AuthPayload): Promise<void> {
+  const res = await fetch(`${API_URL}/auth/login`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to login')
+  }
+}
+
+export async function register(payload: AuthPayload): Promise<void> {
+  const res = await fetch(`${API_URL}/auth/register`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    credentials: 'include',
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error('Failed to register')
+  }
+}
+


### PR DESCRIPTION
## Summary
- add auth service for login and register
- add auth page that toggles between login and registration forms

## Testing
- `npm test` *(fails: Playwright Test did not expect test.describe() to be called here)*

------
https://chatgpt.com/codex/tasks/task_e_68c66f635644832ca8018142eb7370d8